### PR TITLE
✅ Add OS version test

### DIFF
--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -5,6 +5,11 @@ containerRunOptions:
   user: "analyticalplatform"
 
 commandTests:
+  - name: "ubuntu"
+    command: "grep"
+    args: ["DISTRIB_RELEASE", "/etc/lsb-release"]
+    expectedOutput: ["DISTRIB_RELEASE=22.04"]
+
   - name: "whoami"
     command: "whoami"
     expectedOutput: ["analyticalplatform"]


### PR DESCRIPTION
This pull request:

- Adds a test that ensures Ubuntu version is `22.04`

Note:

- Dependabot :dependabot: tried to update Ubuntu from 22.04 to 23.10, which now comes with a user with an ID of `1000` (https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/10)

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 