### PR TITLE
🧑‍💻 Add first-run message to terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY src/opt/visual-studio-code/first-run-notice.txt /opt/visual-studio-code/fir
 
 RUN cat <<EOF >> /home/analyticalplatform/.bashrc
 
+# This is a first run notice for Visual Studio Code
 if [ -t 1 ] && [[ "\${TERM_PROGRAM}" = "vscode" ]] && [ ! -f "/opt/visual-studio-code/first-run-notice-already-displayed" ]; then
     cat /opt/visual-studio-code/first-run-notice.txt
     # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,20 @@ RUN apt-get update --yes \
     && apt-get clean --yes \
     && rm --force --recursive /var/lib/apt/lists/*
 
-# Visaual Studio Code
+COPY src/opt/visual-studio-code/first-run-notice.txt /opt/visual-studio-code/first-run-notice.txt
+
+RUN cat <<EOF >> /home/analyticalplatform/.bashrc
+
+if [ -t 1 ] && [[ "\${TERM_PROGRAM}" = "vscode" ]] && [ ! -f "/opt/visual-studio-code/first-run-notice-already-displayed" ]; then
+    cat /opt/visual-studio-code/first-run-notice.txt
+    # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
+    mkdir -p "~/.visual-studio-code"
+    ((sleep 10s; touch "~/.visual-studio-code/first-run-notice-already-displayed") &)
+fi
+
+EOF
+
+# Visual Studio Code
 RUN curl --location --fail-with-body \
       "https://packages.microsoft.com/keys/microsoft.asc" \
       --output microsoft.asc \

--- a/src/opt/visual-studio-code/first-run-notice.txt
+++ b/src/opt/visual-studio-code/first-run-notice.txt
@@ -1,0 +1,8 @@
+👋 Welcome! You are using the Ministry of Justice Analytical Platform Visual Studio Code image.
+
+🧪 This feature is currently in Beta.
+
+🆘 If you need help or assistance, please post a message into the analytical-platform-vscode-beta Slack Channel.
+
+🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
+

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -33,3 +33,8 @@ commandTests:
     command: "pip"
     args: ["--version"]
     expectedOutput: ["pip.*"]
+
+fileContentTests:
+  - name: "bashrc first-run-notice"
+    path: "/home/analyticalplatform/.bashrc"
+    expectedContents: ["# This is a first run notice for Visual Studio Code"]


### PR DESCRIPTION
This PR runs a message in the terminal for the user on first run. 

![Screenshot 2024-02-28 at 14 08 55](https://github.com/ministryofjustice/analytical-platform-visual-studio-code/assets/26419401/e5f6faff-1348-41f6-a42c-e0ed05454903)

Note a file `~/.visual-studio-code/first-run-notice-already-displayed` is created to determine if this is the first run or note. 

This work is part of [this](https://github.com/ministryofjustice/data-platform/issues/3210) implementation.