### PR TITLE
🔧 `.visual-studio-code` -> `.vscode`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,11 @@ COPY src/opt/visual-studio-code/first-run-notice.txt /opt/visual-studio-code/fir
 RUN cat <<EOF >> /home/analyticalplatform/.bashrc
 
 # This is a first run notice for Visual Studio Code
-if [ -t 1 ] && [[ "\${TERM_PROGRAM}" = "vscode" ]] && [ ! -f "/opt/visual-studio-code/first-run-notice-already-displayed" ]; then
+if [ -t 1 ] && [[ "\${TERM_PROGRAM}" = "vscode" ]] && [ ! -f "/home/analyticalplatform/.vscode/first-run-notice-already-displayed" ]; then
     cat /opt/visual-studio-code/first-run-notice.txt
     # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
-    mkdir -p "~/.visual-studio-code"
-    ((sleep 10s; touch "~/.visual-studio-code/first-run-notice-already-displayed") &)
+    mkdir --parents "/home/analyticalplatform/.vscode"
+    ((sleep 10s; touch "/home/analyticalplatform/.vscode/first-run-notice-already-displayed") &)
 fi
 
 EOF

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Additionally the following tools are installed:
 ### Build
 
 ```bash
-docker build --platform linux/amd64 --file Dockerfile --tag analytical-platform.service.justice.gov.uk/code:local .
+docker build --platform linux/amd64 --file Dockerfile --tag analytical-platform.service.justice.gov.uk/visual-studio-code:local .
 ```
 
 ### Run
@@ -31,7 +31,7 @@ docker run -it --rm \
   --publish 8080:8080 \
   --hostname code \
   --name analytical-platform-code \
-  analytical-platform.service.justice.gov.uk/code:local
+  analytical-platform.service.justice.gov.uk/visual-studio-code:local
 ```
 
 ## Versions


### PR DESCRIPTION
This PR converts `.visual-studio-code` -> `.vscode`, there's no need for there being multiple directories and the `.visual-studio-code` was only needed to store one file.

Additionally this updates the README.md so that when the user calls the `build-and-test.sh` script the image is built with the same name as the command in the README.md