### PR TITLE
♻️ Backup and restore Bash profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,16 @@ RUN apt-get update --yes \
          "python3-pip=22.0.2+dfsg-1ubuntu0.4" \
          "unzip=6.0-26ubuntu3.2" \
     && apt-get clean --yes \
-    && rm --force --recursive /var/lib/apt/lists/*
+    && rm --force --recursive /var/lib/apt/lists/* \
+    && install --directory --owner ${CONTAINER_USER} --group ${CONTAINER_GROUP} --mode 0755 /opt/visual-studio-code
 
+# Backup Bash configuration
+RUN cp /home/analyticalplatform/.bashrc /opt/visual-studio-code/.bashrc \
+    && cp /home/analyticalplatform/.bash_logout /opt/visual-studio-code/.bash_logout \
+    && cp /home/analyticalplatform/.profile /opt/visual-studio-code/.profile
+
+# First run notice
 COPY src/opt/visual-studio-code/first-run-notice.txt /opt/visual-studio-code/first-run-notice.txt
-
 RUN cat <<EOF >> /etc/bash.bashrc
 
 # This is a first run notice for Visual Studio Code

--- a/src/usr/local/bin/entrypoint.sh
+++ b/src/usr/local/bin/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Restore Bash configuration
+cp /opt/visual-studio-code/.bashrc /home/analyticalplatform/.bashrc
+cp /opt/visual-studio-code/.bash_logout /home/analyticalplatform/.bash_logout
+cp /opt/visual-studio-code/.profile /home/analyticalplatform/.profile
+
 mkdir --parent /home/analyticalplatform/workspace
 
 /usr/bin/code serve-web \

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -43,3 +43,21 @@ fileContentTests:
   - name: "bashrc first-run-notice"
     path: "/etc/bash.bashrc"
     expectedContents: ["# This is a first run notice for Visual Studio Code"]
+
+fileExistenceTests:
+  - name: "/opt/visual-studio-code"
+    path: "/opt/visual-studio-code"
+    shouldExist: true
+
+  - name: "/opt/visual-studio-code/.bashrc"
+    path: "/opt/visual-studio-code/.bashrc"
+    shouldExist: true
+
+  - name: "/opt/visual-studio-code/.bash_logout"
+    path: "/opt/visual-studio-code/.bash_logout"
+    shouldExist: true
+
+  - name: "/opt/visual-studio-code/.profile"
+    path: "/opt/visual-studio-code/.profile"
+    shouldExist: true
+


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/data-platform/issues/3478
- Backs up Bash files from `/home/analyticalplatform` to `/opt/visual-studio-code`
- Restores them as part of `/usr/local/bin/entrypoint.sh`

EFS is mapped over `/home/analyticalplatform` so these files aren't present when the pod starts

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 