### PR TITLE
🦙 Add ollama installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV CONTAINER_USER="analyticalplatform" \
     VISUAL_STUDIO_CODE_VERSION="1.87.2-1709912201" \
     AWS_CLI_VERSION="2.15.28" \
     MINICONDA_VERSION="24.1.2-0" \
-    MINICONDA_SHA265="8eb5999c2f7ac6189690d95ae5ec911032fa6697ae4b34eb3235802086566d78" \
+    MINICONDA_SHA256="8eb5999c2f7ac6189690d95ae5ec911032fa6697ae4b34eb3235802086566d78" \
+    OLLAMA_VERSION="0.1.29" \
     PATH="/opt/conda/bin:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -96,12 +97,18 @@ RUN gpg --import /opt/aws-cli/aws-cli@amazon.com.asc \
 RUN curl --location --fail-with-body \
          "https://repo.anaconda.com/miniconda/Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh" \
          --output "miniconda.sh" \
-    && echo "${MINICONDA_SHA265} miniconda.sh" | sha256sum --check \
+    && echo "${MINICONDA_SHA256} miniconda.sh" | sha256sum --check \
     && bash miniconda.sh -b -p /opt/conda \
     && rm --force miniconda.sh
 
 COPY --chown=nobody:nobody --chmod=0755 src/usr/local/bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --chown=nobody:nobody --chmod=0755 src/usr/local/bin/healthcheck.sh /usr/local/bin/healthcheck.sh
+
+# Ollama
+RUN curl --location --fail-with-body \
+        "https://github.com/ollama/ollama/releases/download/v${OLLAMA_VERSION}/ollama-linux-amd64" \
+        --output "ollama" \
+    && install --owner=root --group=root --mode=775 ollama /usr/local/bin/ollama
 
 USER ${CONTAINER_USER}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     MINICONDA_VERSION="24.1.2-0" \
     MINICONDA_SHA256="8eb5999c2f7ac6189690d95ae5ec911032fa6697ae4b34eb3235802086566d78" \
     OLLAMA_VERSION="0.1.29" \
+    OLLAMA_SHA256="332911072ca8bc2d41323582eed4d42205074b7ba82e7008d4e75761a1260b0e" \
     PATH="/opt/conda/bin:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -108,7 +109,9 @@ COPY --chown=nobody:nobody --chmod=0755 src/usr/local/bin/healthcheck.sh /usr/lo
 RUN curl --location --fail-with-body \
         "https://github.com/ollama/ollama/releases/download/v${OLLAMA_VERSION}/ollama-linux-amd64" \
         --output "ollama" \
-    && install --owner=root --group=root --mode=775 ollama /usr/local/bin/ollama
+    && echo "${OLLAMA_SHA256} ollama" | sha256sum --check \
+    && install --owner=root --group=root --mode=775 ollama /usr/local/bin/ollama \
+    && rm --force ollama
 
 USER ${CONTAINER_USER}
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Additionally the following tools are installed:
 
 - [AWS CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/index.html)
 - [Miniconda](https://docs.anaconda.com/free/miniconda/index.html)
+- [Ollama](https://ollama.com/)
 
 ## Running Locally
 
@@ -89,3 +90,10 @@ As of 20/02/24, the GPG public key used for verifying AWS CLI expires 26/07/24, 
 ### Miniconda
 
 Releases for Miniconda are maintained on [docs.anaconda.com](https://docs.anaconda.com/free/miniconda/miniconda-release-notes/), from there we can use [repo.anaconda.com](https://repo.anaconda.com/miniconda/) to determine the artefact name and SHA256 based on a version. We currently use `py310`, `Linux` and `x86_64`variant.
+
+### Ollama
+
+Ollama is a tool that allows you to run open-source large language models (LLMs) locally on your machine. It supports a variety of models, including Llama 2, Code Llama, and others.
+
+Ollama don't currently provide SHA256 checksum for their installation file. For now, a checksum was acquired by runing the following comand locally:
+`curl --location --fail-with-body "https://github.com/ollama/ollama/releases/download/v0.1.29/ollama-linux-amd64" | sha256sum`

--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ Releases for Miniconda are maintained on [docs.anaconda.com](https://docs.anacon
 
 Ollama is a tool that allows you to run open-source large language models (LLMs) locally on your machine. It supports a variety of models, including Llama 2, Code Llama, and others.
 
-Ollama don't currently provide SHA256 checksum for their installation file. For now, a checksum was acquired by runing the following comand locally:
+Ollama don't currently provide SHA256 checksum for their installation file. For now, a checksum was acquired by running the following command locally:
 `curl --location --fail-with-body "https://github.com/ollama/ollama/releases/download/v0.1.29/ollama-linux-amd64" | sha256sum`

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -41,11 +41,8 @@ commandTests:
 
   - name: "ollama"
     command: "ollama"
-    #args: ["--version"]
-    args:
-      - "serve"
-      - "--version"
-    expectedOutput: ["ollama version 0.1.29"]
+    args: ["--version"]
+    expectedOutput: [".*version.*"]
 
 fileContentTests:
   - name: "bashrc first-run-notice"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -39,6 +39,11 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["pip.*"]
 
+  - name: "ollama"
+    command: "ollama"
+    args: ["--version"]
+    expectedOutput: ["*version*"]
+
 fileContentTests:
   - name: "bashrc first-run-notice"
     path: "/etc/bash.bashrc"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -41,7 +41,10 @@ commandTests:
 
   - name: "ollama"
     command: "ollama"
-    args: ["--version"]
+    #args: ["--version"]
+    args:
+      - "serve"
+      - "--version"
     expectedOutput: ["ollama version 0.1.29"]
 
 fileContentTests:

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,7 +42,7 @@ commandTests:
   - name: "ollama"
     command: "ollama"
     args: ["--version"]
-    expectedOutput: ["*version*"]
+    expectedOutput: ["ollama version 0.1.29"]
 
 fileContentTests:
   - name: "bashrc first-run-notice"


### PR DESCRIPTION
This pull request:

- Contributes to work on https://github.com/ministryofjustice/data-platform/issues/3611
- Adds ollama installation to the Dockerfile with SHA256 check
- Adds test for ollama in `container-structure-test.yml`
- Updates README to include detais for ollama