### PR TITLE
🌊 Add Microsoft .NET SDK

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,1 @@
+GHSA-vh55-786g-wjwj # This is not something we can patch (https://github.com/ministryofjustice/analytical-platform-visual-studio-code/security/code-scanning/1)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Additionally the following tools are installed:
 - [AWS CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/index.html)
 - [Amazon Corretto](https://aws.amazon.com/corretto)
 - [Miniconda](https://docs.anaconda.com/free/miniconda/index.html)
+- [.NET SDK](https://learn.microsoft.com/en-us/dotnet/core/sdk)
 - [Ollama](https://ollama.com/)
 
 ## Running Locally

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -50,6 +50,11 @@ commandTests:
     args: ["-version"]
     exitCode: 0
 
+  - name: "dotnet"
+    command: "dotnet"
+    args: ["--version"]
+    expectedOutput: ["8.*"]
+
 fileContentTests:
   - name: "bashrc first-run-notice"
     path: "/etc/bash.bashrc"


### PR DESCRIPTION
This pull request:

- Installs .NET from Microsoft Package Repository
- Updates AWS Command Line Interface
- Style and formatting fixes
- Adds `.trivyignore` to exclude `GHSA-vh55-786g-wjwj`

Note: This pull request is failing the image scanning workflow, due to a detected vulnerability in `/usr/share/dotnet/sdk/8.0.202/Roslyn/Microsoft.Build.Tasks.CodeAnalysis.deps.json`. This is something we cannot patch currently, as we are already using the latest release of `dotnet-sdk-8.0` from Microsoft

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 