### PR TITLE
🔀 Switch base image to NVIDIA's Ubuntu 22.04 CUDA base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/ubuntu/ubuntu@sha256:1cc4019c277242e5fb710f2cf40af1590ad053b7d764efba48b051871dcc18d8
+FROM docker.io/nvidia/cuda:12.4.1-base-ubuntu22.04
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \


### PR DESCRIPTION
This pull request:

Is part of https://github.com/ministryofjustice/analytical-platform/issues/4120

- Switches to `nvidia/cuda:12.4.1-base-ubuntu22.04`
  - source https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.4.1/ubuntu2204/base/Dockerfile

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 