### PR TITLE
📌 06/01/2025 Patching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
         with:
           confirm: true
 
@@ -56,14 +56,14 @@ jobs:
 
       - name: Generate SBOM
         id: generate_sbom
-        uses: anchore/sbom-action@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
+        uses: anchore/sbom-action@df80a981bc6edbc4e220a492d3cbe9f5547a6e75 # v0.17.9
         with:
           image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           format: cyclonedx-json
           output-file: "sbom.cyclonedx.json"
 
       - name: Attest
-        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
+        uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
         id: attest
         with:
           subject-name: ghcr.io/${{ github.repository }}
@@ -71,7 +71,7 @@ jobs:
           push-to-registry: true
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1.4.1
+        uses: actions/attest-sbom@cbfd0027ae731a5892db25ecd226930d7ffd19eb # v2.1.0
         id: attest_sbom
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
         with:
           confirm: true
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Super-Linter
         id: super_linter
-        uses: super-linter/super-linter/slim@e1cb86b6e8d119f789513668b4b30bf17fe1efe4 # v7.2.0
+        uses: super-linter/super-linter/slim@85f7611e0f7b53c8573cca84aa0ed4344f6f6a4d # v7.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set Up Container Structure Test
         id: setup_container_structure_test
-        uses: ministryofjustice/github-actions/setup-container-structure-test@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/setup-container-structure-test@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
 
       - name: Test
         id: test

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,6 @@
 # Ubuntu
 CVE-2024-43882
+CVE-2024-53103
 
 # Python
 ## setuptools
@@ -18,3 +19,5 @@ CVE-2024-0057
 ## aws-sso
 CVE-2024-41110 # Vulnerability in github.com/docker/docker, but we don't run Docker on CDE
 CVE-2024-34156
+CVE-2024-45337
+CVE-2024-45338

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base@sha256:84566c75d229f62ce76f549d999dfc68ba93af0dce65175efb6e410d6b160da8
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base@sha256:c1313aef75dd4a07af859336d152b8e0a8220b1a8af664b750d79cd8af65265d
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="Visual Studio Code image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-visual-studio-code"
 
-ENV VISUAL_STUDIO_CODE_VERSION="1.95.3-1731513102"
+ENV VISUAL_STUDIO_CODE_VERSION="1.96.2-1734607745"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "code"
     command: "code"
     args: ["--version"]
-    expectedOutput: ["1.95.3"]
+    expectedOutput: ["1.96.2"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
This pull request:

- Supersedes
  - https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/183
  - https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/184
  - https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/185
  - https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/186
  - https://github.com/ministryofjustice/analytical-platform-visual-studio-code/pull/187
- Updates CDE Base to [1.9.0](https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/releases/tag/1.9.0)
- Updates Visual Studio Code to [1.96.2](https://code.visualstudio.com/updates/v1_96)
- Added skips for CVEs we cannot patch
  - CVE-2024-53103
  - CVE-2024-45337
  - CVE-2024-45338

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 