### PR TITLE
⏰ Add scheduled scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 10 * * 1-5" # Every weekday at 9AM UTC
 
 permissions: {}
 
@@ -58,3 +60,16 @@ jobs:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL
           exit-code: 1
+
+      - name: Slack CVE Alert
+        if: failure() && github.event_name == 'schedule' && steps.scan.outcome == 'failure'
+        id: slack_cve_alert
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.CVE_SCAN_SLACK_WEBHOOK_URL }}
+          payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "run_id": "${{ github.run_id }}"
+            }


### PR DESCRIPTION
## Proposed Changes

- Updates scanning workflow to run Monday to Friday at 1000 UTC (staggered from CDE base at 0900)
- Enables a Slack notification if a new CVE is detected

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>