### PR TITLE
⬆️ Bump VS Code to 1.98.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="Visual Studio Code image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-visual-studio-code"
 
-ENV VISUAL_STUDIO_CODE_VERSION="1.98.1-1741624510"
+ENV VISUAL_STUDIO_CODE_VERSION="1.98.2-1741788907"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "code"
     command: "code"
     args: ["--version"]
-    expectedOutput: ["1.98.1"]
+    expectedOutput: ["1.98.2"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
## Proposed Changes

- Update VS Code to [1.98.2](https://github.com/microsoft/vscode/releases/tag/1.98.2)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>