### PR TITLE
Skip CVE's picked up by CVE scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,7 @@
 # Ubuntu
 CVE-2024-53140
 CVE-2024-56595
+
+# Go
+## CVE-2025-22869 (usr/bin/ollama, usr/local/bin/aws-sso, usr/local/bin/cloud-platform)
+CVE-2025-22869


### PR DESCRIPTION
 The scheduled container scan identified these CVE  [issues](https://github.com/ministryofjustice/analytical-platform-visual-studio-code/actions/runs/14488866489/job/40640463478#step:6:442)
See the [following](https://avd.aquasec.com/nvd/2025/cve-2025-22869/) for more detail.

Unfortunately the potential mitigations would require a code re write and the mitigations can introduce issues of their own