### PR TITLE
CVE-2025-22868 alert patching 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,9 @@
 # Ubuntu
 CVE-2024-53140
 CVE-2024-56595
+
+## CVE-2025-22868 (usr/local/bin/cloud-platform, usr/local/bin/kubectl)
+CVE-2025-22868
+
+## CVE-2022-40898 (Python (python-pkg))
+CVE-2022-40898

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.25.0@sha256:c67b957208a5f2753088f48c023791dcec95cea14488793a1e4d887ae2fa9f10
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.26.0@sha256:51960c8f6ca021a09c196c85aa97693b28a5240baa11dbc97245e04e0c1adf98
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="Visual Studio Code image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-visual-studio-code"
 
-ENV VISUAL_STUDIO_CODE_VERSION="1.101.1-1750254731"
+ENV VISUAL_STUDIO_CODE_VERSION="1.102.2-1753187809"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "code"
     command: "code"
     args: ["--version"]
-    expectedOutput: ["1.101.1"]
+    expectedOutput: ["1.102.2"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
### Updates

| Variable                         | Old Version                          | New Version                          |
|----------------------------------|--------------------------------------|--------------------------------------|
| `CDE Base`               | `1.25.0`                            | `1.26.0`                            |
| `Visual Studio Code`    | `1.101.1`                             | `1.102.2`                             |

Updating CDE Base to latest versions failed to resolve [cve-2025-22868](https://avd.aquasec.com/nvd/cve-2025-22868 ) and introduced [cve-2022-40898](https://avd.aquasec.com/nvd/cve-2022-40898) I have added these to the trivy ignore here as well.