### PR TITLE
📌 Patch 01/05/26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.42.1@sha256:c377dda0bdfdfe7fe71d6eda79adaa6db5893fce19291026bfbd52bf4da5ea5d
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.0@sha256:0c941a0c684ae4187aeef0d1e8146b868210fae4e94c19bf88fb1ad43ad31e42
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
       org.opencontainers.image.title="Visual Studio Code" \
       org.opencontainers.image.description="Visual Studio Code image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-visual-studio-code"
 
-ENV VISUAL_STUDIO_CODE_VERSION="1.110.1-1772839366"
+ENV VISUAL_STUDIO_CODE_VERSION="1.118.1-1777474985"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "code"
     command: "code"
     args: ["--version"]
-    expectedOutput: ["1.110.1"]
+    expectedOutput: ["1.118.1"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
## Proposed Changes

- Updates CDE Base to [1.43.0](https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/releases/tag/1.43.0)
- Updates VS Code to [1.118](https://code.visualstudio.com/updates/v1_118)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>