### PR TITLE
changed schedule run from 9AM to 7AM

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@497b26456c1f0cff118cf5f663b66794d368f3e8 # v8.0.2
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@aa8abd093cd24a89b8dd2d76b6733d8121c64c52 # v8.0.3
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.1@sha256:08fb5935dbe1604a3c225782930c6c9a8384781916fde03731e89045691c44bc
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.2@sha256:c5b66b6f6a0a02bc90a365979b1760752a53fbcbe3f8b1bf7669c00940c3656e
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
       org.opencontainers.image.title="Visual Studio Code" \


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Additional changes
- build using latest cloud-base image `1.43.2`
- pinned latest version of scheduled run actions

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.