### PR TITLE
pinning latest patched base image version

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -309,3 +309,17 @@ ignore:
       name: uuid
       location: "/usr/share/code/resources/app/node_modules/uuid/package.json"
     reason: "Bundled in VS Code's app node_modules; fixed upstream in uuid 11.1.1. Requires a newer VS Code release. exp:2026-08-01"
+  - vulnerability: GHSA-395f-4hp3-45gv
+    package:
+      type: npm
+      name: shell-quote
+      version: "1.8.4"
+      location: "/usr/share/code/resources/app/node_modules/shell-quote/package.json"
+    reason: "Bundled directly in VS Code's app node_modules; fixed upstream in shell-quote 1.9.0. Requires a newer VS Code release. exp:2026-08-01"
+  - vulnerability: GHSA-gcfj-64vw-6mp9
+    package:
+      type: npm
+      name: axios
+      version: "1.16.0"
+      location: "/usr/share/code/resources/app/node_modules/axios/package.json"
+    reason: "Bundled directly in VS Code's app node_modules; fixed upstream in axios 1.18.0. Requires a newer VS Code release. exp:2026-08-01"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.2@sha256:c5b66b6f6a0a02bc90a365979b1760752a53fbcbe3f8b1bf7669c00940c3656e
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.4@sha256:d0cbcfe02c8f007de8d983ec179a1185dd6f4e36e9c8e14fbb4bc7ae44de4df0
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
       org.opencontainers.image.title="Visual Studio Code" \


### PR DESCRIPTION
- added ignore for known vuln `GHSA-395f-4hp3-45gv` and `GHSA-gcfj-64vw-6mp9`
- pinned latest version of  `analytical-platform-cloud-development-environment-base` image `1.43.4`