### PR TITLE
build: update Visual Studio Code package version

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,27 +1,37 @@
 {
   "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "2.16.0",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:31ef1bbfde793bcc62c52fa847c02a15fe659d69e48b2d8c1cfbd4db95f97cf7",
       "integrity": "sha256:31ef1bbfde793bcc62c52fa847c02a15fe659d69e48b2d8c1cfbd4db95f97cf7"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:": {
+    "ghcr.io/devcontainers/features/github-cli:": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/apm:1.0.0": {
       "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test@sha256:19eb30f9eb327b667be2002757d55381de87cdb5a79a6e37d293369fe8ad01ad",
-      "integrity": "sha256:19eb30f9eb327b667be2002757d55381de87cdb5a79a6e37d293369fe8ad01ad",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/apm@sha256:b562e126312767cf69b772bce79ae551a82f97c2eda7cce400fe068530261f71",
+      "integrity": "sha256:b562e126312767cf69b772bce79ae551a82f97c2eda7cce400fe068530261f71"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:1.0.1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test@sha256:98cd8301fb4047c44a21d1b481ac14d7c2f94b86bbd3a7dec47bcf2f6d5b48d8",
+      "integrity": "sha256:98cd8301fb4047c44a21d1b481ac14d7c2f94b86bbd3a7dec47bcf2f6d5b48d8",
       "dependsOn": [
         "ghcr.io/devcontainers/features/docker-in-docker:2"
       ]
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16",
-      "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
-    },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901",
+      "integrity": "sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/apm:1.0.0": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:1.0.1": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:": {},
     "ghcr.io/devcontainers/features/github-cli:": {}
   },
@@ -15,5 +16,6 @@
         "GitHub.vscode-pull-request-github"
       ]
     }
-  }
+  },
+  "postCreateCommand": "/bin/bash .devcontainer/post-create.sh"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo apt-get update
+
+# Install agent package manager dependencies.
+apm install --frozen

--- a/.github/instructions/language.instructions.md
+++ b/.github/instructions/language.instructions.md
@@ -1,0 +1,7 @@
+---
+description: Language instructions
+---
+
+# Language
+
+Always use British English.

--- a/.github/instructions/ministryofjustice.instructions.md
+++ b/.github/instructions/ministryofjustice.instructions.md
@@ -1,0 +1,9 @@
+---
+description: Ministry of Justice Standards
+---
+
+# Ministry of Justice Standards
+
+- Adhere to guidance published under [ministryofjustice/.github](https://github.com/ministryofjustice/.github)
+- Follow security best practices for government services
+- Always use MOJ as the abbreviation for Ministry of Justice, not MoJ or moj

--- a/.github/prompts/maintenance.prompt.md
+++ b/.github/prompts/maintenance.prompt.md
@@ -1,0 +1,119 @@
+---
+description: "Perform monthly maintenance for this repository: update the cloud base image digest and Visual Studio Code package version, update tests, and complete the manual maintenance Definition of Done"
+tools:
+  [
+    "search/codebase",
+    "search",
+    "edit/editFiles",
+    "execute/runInTerminal",
+    "execute/getTerminalOutput",
+  ]
+---
+
+# Maintenance
+
+Perform monthly maintenance for this repository. This image depends on the Analytical Platform Cloud Base Development Image and pins a Visual Studio Code Debian package version. Update both where needed, update the container structure test expectation, and prepare one pull request.
+
+Use the current values from `Dockerfile` and `test/container-structure-test.yml`. Do not assume versions.
+
+## Prerequisite
+
+Reminder: this maintenance depends on the Analytical Platform Cloud Base Development Image maintenance issue being completed first.
+
+- Dependency repository: `ministryofjustice/analytical-platform-cloud-development-environment-base`
+- Treat this as a manual pre-check by the user running the ticket.
+
+## Objective
+
+In one pull request:
+
+1. Update the pinned base image digest in `Dockerfile` for the existing image and tag.
+2. Update `VISUAL_STUDIO_CODE_VERSION` in `Dockerfile` if a newer Debian package version is available.
+3. Update the `code --version` expected output in `test/container-structure-test.yml` when Visual Studio Code is updated.
+4. Keep everything else unchanged.
+
+## Required Outcome
+
+1. Create one maintenance branch.
+2. Commit all required file updates with a Conventional Commit (`build:`).
+3. Push and open one pull request.
+4. Include a checklist aligned to the manual maintenance ticket Definition of Done.
+
+## Execution Steps
+
+1. Create a maintenance branch.
+
+```bash
+git checkout -b "chore/maintenance-vscode-$(date +%Y%m%d-%H%M%S)"
+```
+
+2. Update the base image digest in `Dockerfile`.
+
+- Read the current `FROM` image and tag from `Dockerfile`.
+- Use the latest release tag from `ministryofjustice/analytical-platform-cloud-development-environment-base`.
+- Pull for `linux/amd64` and inspect the digest.
+- Update only the digest in the `FROM` line. Keep repository and tag unchanged.
+
+Reference commands from the README:
+
+```bash
+docker pull --platform linux/amd64 ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:$(curl --silent https://api.github.com/repos/ministryofjustice/analytical-platform-cloud-development-environment-base/releases/latest | jq -r .tag_name)
+
+docker image inspect --format='{{index .RepoDigests 0}}' ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:$(curl --silent https://api.github.com/repos/ministryofjustice/analytical-platform-cloud-development-environment-base/releases/latest | jq -r .tag_name)
+```
+
+3. Check whether `VISUAL_STUDIO_CODE_VERSION` should be updated.
+
+- Get the latest Visual Studio Code release tag from `microsoft/vscode`.
+- Query the Microsoft Debian package feed and locate the amd64 package entry matching that release.
+- Extract the full Debian version string (example format: `1.86.2-1707854558`).
+- Compare with `VISUAL_STUDIO_CODE_VERSION` in `Dockerfile`.
+- If newer, update `VISUAL_STUDIO_CODE_VERSION`.
+
+Reference command from the README:
+
+```bash
+curl --silent https://packages.microsoft.com/repos/code/pool/main/c/code/ | grep $(curl --silent https://api.github.com/repos/microsoft/vscode/releases/latest | jq -r .tag_name) | grep amd64
+```
+
+4. Update test expectations when Visual Studio Code changes.
+
+- In `test/container-structure-test.yml`, update the `commandTests` entry for `code --version`.
+- The expected output should contain only the semantic version part (for example `1.110.1`), not the Debian build suffix.
+
+5. Validate changes.
+
+```bash
+make test
+```
+
+6. Commit, push, and open a pull request.
+
+- Use a Conventional Commit message with type `build`.
+- Use a clear PR title, for example: `build: update cloud base image digest and Visual Studio Code version`.
+- Include a concise PR summary of changed versions.
+
+## Pull Request Checklist
+
+Include this checklist in the PR description and complete each item:
+
+### Definition of Done
+
+Since this image relies on the Analytical Platform Cloud Base Development Image, ensure that maintenance issue is completed first.
+
+- [ ] Merge any open Dependabot pull requests in the Visual Studio Code repository.
+- [ ] Update the Visual Studio Code version if required.
+- [ ] Create a new release in this repository.
+- [ ] Update guidance if required: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/visual-studio-code/#visual-studio-code
+- [ ] Create a new release in development: https://controlpanel.services.dev.analytical-platform.service.justice.gov.uk/releases/
+- [ ] Test deployment in development.
+- [ ] Create a new release in production: https://controlpanel.services.analytical-platform.service.justice.gov.uk/releases/
+- [ ] Test deployment in production.
+
+## Guardrails
+
+- Keep platform aligned to `linux/amd64` for digest checks.
+- Do not change the base image repository or tag in `FROM`; update only digest.
+- Do not change unrelated Dockerfile content.
+- Do not update `test/container-structure-test.yml` unless Visual Studio Code version changed.
+- Keep all maintenance updates in a single branch and a single pull request.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ env/
 *.code-workspace
 *.sha256
 terraform.tfstate
+apm_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="Visual Studio Code image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-visual-studio-code"
 
-ENV VISUAL_STUDIO_CODE_VERSION="1.110.1-1772839366"
+ENV VISUAL_STUDIO_CODE_VERSION="1.132.0-1785860022"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Open a browser <http://localhost:8080/?folder=/home/analyticalplatform/workspace
 
 ## Managing Software Versions
 
+This repository includes a Copilot prompt for maintenance in [`.github/prompts/`](.github/prompts/). To run it, open Copilot Chat in Visual Studio Code and type `/maintenance`. The prompt updates the Ubuntu base image digest and the pinned APT package versions in the [Dockerfile](./Dockerfile) and prepares a single pull request.
+
 ### Base Image
 
 Generally Dependabot does this, but the following command will return the digest:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,61 @@
+lockfile_version: '1'
+generated_at: '2026-08-07T11:37:16.674838+00:00'
+apm_version: 0.28.0
+dependencies:
+- repo_url: ministryofjustice/data-platform-ai-toolkit
+  name: universal
+  host: github.com
+  resolved_commit: 943ecee009ac2d9717811b90af2701e4134c1bcf
+  resolved_ref: main
+  version: 1.0.0
+  virtual_path: toolkits/universal
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/language.instructions.md
+  - .github/instructions/ministryofjustice.instructions.md
+  deployed_file_hashes:
+    .github/instructions/language.instructions.md: sha256:70e9d0f220f2ceec1cf5b8088c9e199259670f9baa383b330ff3ba9e4107e655
+    .github/instructions/ministryofjustice.instructions.md: sha256:470dc2fbec601f32b14b73f6665a17dd7e3427c0bcdc5c8197c5e3905d30dfcc
+  content_hash: sha256:d375ca1db8fc999bc92d31994eba9aa81611fb48d0750d557e4d27ab1249f68e
+deployments:
+- kind: project-relative
+  target: copilot
+  value: .github/instructions/language.instructions.md
+  runtime: null
+  scope: project
+  owners:
+  - ministryofjustice/data-platform-ai-toolkit/toolkits/universal
+  active_owner: ministryofjustice/data-platform-ai-toolkit/toolkits/universal
+  content_hash: sha256:70e9d0f220f2ceec1cf5b8088c9e199259670f9baa383b330ff3ba9e4107e655
+- kind: project-relative
+  target: copilot
+  value: .github/instructions/ministryofjustice.instructions.md
+  runtime: null
+  scope: project
+  owners:
+  - ministryofjustice/data-platform-ai-toolkit/toolkits/universal
+  active_owner: ministryofjustice/data-platform-ai-toolkit/toolkits/universal
+  content_hash: sha256:470dc2fbec601f32b14b73f6665a17dd7e3427c0bcdc5c8197c5e3905d30dfcc
+- kind: uri
+  target: mcp
+  value: github
+  runtime: vscode
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
+mcp_servers:
+- github
+mcp_configs:
+  github:
+    name: github
+    transport: http
+    registry: false
+    url: https://api.githubcopilot.com/mcp/
+mcp_target_servers:
+  vscode:
+  - github
+mcp_config_provenance:
+  github: universal

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,8 @@
+---
+version: 1.0.0
+name: analytical-platform-actions-runner
+targets:
+  - copilot
+dependencies:
+  apm:
+    - ministryofjustice/data-platform-ai-toolkit/toolkits/universal#main

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "code"
     command: "code"
     args: ["--version"]
-    expectedOutput: ["1.110.1"]
+    expectedOutput: ["1.132.0"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
## Summary
Updates pinned Visual Studio Code dependencies in `Dockerfile` and aligns the version assertion in `test/container-structure-test.yml`.

### Base image
- `ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.42.1` digest is already up to date.
- No base image change in this PR.

### Visual Studio Code
| Item | Before | After |
| --- | --- | --- |
| `VISUAL_STUDIO_CODE_VERSION` | `1.110.1-1772839366` | `1.132.0-1785860022` |
| `code --version` expected output | `1.110.1` | `1.132.0` |

